### PR TITLE
Changes for parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<includes>
+							<!-- <includes>
 								<include>**/RunnerTest.java</include>
-							</includes>
+							</includes> -->
 							<parallel>methods</parallel>
 							<threadCount>4</threadCount>
 							<perCoreThreadCount>true</perCoreThreadCount>

--- a/src/test/java/testRunner/RunnerTestIT.java
+++ b/src/test/java/testRunner/RunnerTestIT.java
@@ -9,6 +9,6 @@ import io.cucumber.junit.CucumberOptions;
 @CucumberOptions(features = { "src//test//resources//features" }, glue = { "stepDefinitions", "appHooks" }, plugin = {
 		"pretty", "com.aventstack.extentreports.cucumber.adapter.ExtentCucumberAdapter:",
 		"timeline:test-output-thread/" }/* , monochrome = true, publish = true */)
-public class RunnerTest {
+public class RunnerTestIT {
 
 }


### PR DESCRIPTION
U are executing the runner twice in surefire and firesafe plugin. Run only once as pdf report does not support multiple runners. Refer to the article - https://grasshopper.tech/2098/ - search for 'PDF Extent Report'